### PR TITLE
Alter initial Cypress test to pass for CircleCI

### DIFF
--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -4,8 +4,8 @@ describe("Main page spec", () => {
         cy.visit('http://localhost:3000/');
     })
 
-    it('Should contain the string "Hello World!"',  () => {
-        cy.get('main').should('contain', 'Hello world!')
+    it('Should contain the string "Seen"',  () => {
+        cy.get('main').should('contain', 'Seen')
 
     })
 


### PR DESCRIPTION
# Description

Alter initial Cypress test to pass for CircleCI - test was looking for "Hello World" and failed - now changed to look for "Seen"

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor

# How Has This Been Tested?